### PR TITLE
Issue #3: Added job logging by using the PHP output buffer.

### DIFF
--- a/TripalDaemon.inc
+++ b/TripalDaemon.inc
@@ -80,7 +80,20 @@ class TripalDaemon extends DrushDaemon {
       // Launch all tripal jobs :) Yay for bootstrapping!!
       foreach ($job_ids as $id) {
         $this->log('Starting Job (ID=' . $id . ')', '', 1);
+
+        // We would like to log the output from the job.
+        // However, most tripal jobs simply print to the screen :-(
+        // Thus we have to use output buffering to capture the output.
+        // Start Buffering.
+        ob_start();
+
+        // Launch Tripal Job.
         tripal_launch_job(FALSE, $id);
+
+        // Save the buffer to the log and stop buffering.
+        $this->log(str_repeat('=', 80));
+        $this->log(ob_get_clean());
+        $this->log(str_repeat('=', 80));
 
         // Report job details.
         $job = db_query(


### PR DESCRIPTION
Solves Issue #3.

## Description
Originally the Tripal Daemon would log when it started the job and when it was complete. The actual output of that job, however, was lost forever. This makes debugging of Tripal Jobs run on production sites extremely difficult.

## How Fixed
I fixed this by using PHP output buffering to capture the output of the job and then added it to the already existing log.

## How to test
Simply run a job of Tripal2 Dev site. It will be picked up by the daemon and then you can use `drush trpjob-daemon show-log`.