### PR TITLE
Add Configuration UI

### DIFF
--- a/includes/tripal_daemon.admin.inc
+++ b/includes/tripal_daemon.admin.inc
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Administration of the Tripal Drush Daemon.
+ */
+
+/**
+ * Settings Form.
+ */
+function tripal_daemon_admin_settings_form($form, $form_state) {
+
+  $form['msg'] = array(
+    '#type' => 'item',
+    '#markup' => 'The following form allows you to provide settings for the 
+      Tripal Drush Daemon. Keep in mind, some of these settings may be overriden
+      when the daemon is run on the command-line.',
+  );
+
+  return $form;
+}

--- a/includes/tripal_daemon.admin.inc
+++ b/includes/tripal_daemon.admin.inc
@@ -11,10 +11,42 @@ function tripal_daemon_admin_settings_form($form, $form_state) {
 
   $form['msg'] = array(
     '#type' => 'item',
-    '#markup' => 'The following form allows you to provide settings for the 
+    '#markup' => 'The following form allows you to provide settings for the
       Tripal Drush Daemon. Keep in mind, some of these settings may be overriden
       when the daemon is run on the command-line.',
   );
 
+  $form['notifications'] = array(
+    '#type' => 'fieldset',
+    '#title' => 'Notifications',
+  );
+
+  $form['notifications']['notify'] = array(
+    '#title' => 'Notify Admin by Email if not running.',
+    '#type' => 'checkbox',
+    '#description' => 'The email of the admin user (uid=1) will be contacted whenever drupal cron detects the Tripal Daemon is not running.',
+    '#default_value' => variable_get('tripald_daemon_notify', TRUE),
+  );
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => 'Save Settings',
+  );
+
   return $form;
+}
+
+/**
+ * Settings Form: Validate
+ */
+function tripal_daemon_admin_settings_form_validate($form, &$form_state) { }
+
+/**
+ * Settings Form: Submit
+ */
+function tripal_daemon_admin_settings_form_submit($form, &$form_state) {
+
+  // Save Notification Settings.
+  variable_set('tripald_daemon_notify', $form_state['values']['notify']);
+
 }

--- a/includes/tripal_daemon.admin.inc
+++ b/includes/tripal_daemon.admin.inc
@@ -21,6 +21,15 @@ function tripal_daemon_admin_settings_form($form, $form_state) {
     '#title' => 'Notifications',
   );
 
+  $admin_user = user_load(1);
+  $form['notifications']['email'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Email',
+    '#description' => 'The email address the notification will be sent to',
+    '#disabled' => TRUE,
+    '#value' => $admin_user->mail,
+  );
+
   $form['notifications']['notify'] = array(
     '#title' => 'Notify Admin by Email if not running.',
     '#type' => 'checkbox',
@@ -48,5 +57,23 @@ function tripal_daemon_admin_settings_form_submit($form, &$form_state) {
 
   // Save Notification Settings.
   variable_set('tripald_daemon_notify', $form_state['values']['notify']);
+
+  // Actually handle turning off/on the email.
+  // Currently the drush daemon has no way to configure this option :-(
+  // However, the daemon saves the timestamp for when to next check if the daemon is
+  // dead in a Drupal Variable. Thus we can highjack that variable to tell Drush Daemon
+  // to never check the daemon by setting this variable to FALSE.
+  if ($form_state['values']['notify'] == FALSE) {
+    variable_set('drushd_next_notification_tripal_daemon', FALSE);
+    drupal_set_message('Notifications for Tripal Daemon are turned off. This means that if the daemon dies unexpectedly you will not be notified via email.', 'warning');
+  }
+  // Ensure the daemon notification is turned on.
+  // Turn the daemon notification back on by setting the next time to check the daemon
+  // to the current time.
+  else {
+    variable_set('drushd_next_notification_tripal_daemon', time());
+    drupal_set_message('Notifications for Tripal Daemon are turned on.');
+
+  }
 
 }

--- a/tripal_daemon.info
+++ b/tripal_daemon.info
@@ -3,6 +3,8 @@ description = Creates a Daemon to run Tripal Jobs as they are submitted.
 core = 7.x
 package = Tripal Extensions
 
+configure = admin/tripal/extension/tripal_daemon/settings
+
 dependencies[] = drushd
 dependencies[] = tripal_core
 

--- a/tripal_daemon.module
+++ b/tripal_daemon.module
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Non-Drush Tripal Daemon functionality.
@@ -21,4 +20,23 @@ function tripal_daemon_daemon_api_info() {
   );
 
   return $daemon;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function tripal_daemon_menu() {
+  $items = array();
+
+  $items['admin/tripal/extension/tripal_daemon/settings'] = array(
+    'title' => 'Settings',
+    'description' => 'Default settings for the Tripal Drush Daemon.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('tripal_daemon_admin_settings_form'),
+    'access arguments' => array('administer tripal'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'includes/tripal_daemon.admin.inc',
+   );
+
+  return $items;
 }


### PR DESCRIPTION
See Issue #6 

## Description
Created a configuration form at [drupal site]/admin/tripal/extension/tripal_daemon/settings with one option for now: turn on/off email notification for death of Tripal Daemon.

## Approach
Notifying the admin when the daemons dies is implemented in Drush Daemon (Tripal Daemon is an extension of this module). Unfortunately the Drush Daemon does not provide configuration to turn on/off these notifications. However, it does save the timestamp for when to next check if the daemon is dead in a Drupal Variable (`drushd_next_notification_tripal_daemon`). Thus we can highjack that variable to tell Drush Daemon to never check the daemon by setting this variable to FALSE. This takes advantage of PHP boolean handling (see [Example #1](http://php.net/manual/en/language.operators.comparison.php) ) which says that `time() >= FALSE` will evaluate to FALSE and result in the daemon not being checked.

## How to Test
This modification is live on Dev/Fresh so you can confirm the form renders and checking/unchecking the checkbox gives the correct message. Unfortunately the email is sent to my email address and cannot be configured (Always sends to the god user) so others can't test this. Thus I discussed my testing method and results directly with @carolyncaron so she could review my process.